### PR TITLE
Support sharing connection pool client.

### DIFF
--- a/.changeset/shaggy-cycles-compare.md
+++ b/.changeset/shaggy-cycles-compare.md
@@ -1,0 +1,5 @@
+---
+'@tirke/node-cache-manager-mongodb': minor
+---
+
+Add possibility to pass a Mongo Client to the constructor

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,16 +43,14 @@
             "newlines-between": "always"
           }
         ],
-        "@typescript-eslint/no-extra-semi": "error",
-        "no-extra-semi": "off"
+        "no-extra-semi": "error"
       }
     },
     {
       "files": ["*.js", "*.jsx"],
       "extends": ["plugin:@nx/javascript"],
       "rules": {
-        "@typescript-eslint/no-extra-semi": "error",
-        "no-extra-semi": "off"
+        "no-extra-semi": "error"
       }
     }
   ]

--- a/packages/node-cache-manager-mongodb/src/lib/node-cache-manager-mongodb.spec.ts
+++ b/packages/node-cache-manager-mongodb/src/lib/node-cache-manager-mongodb.spec.ts
@@ -1,4 +1,5 @@
 import { caching } from 'cache-manager'
+import { MongoClient } from 'mongodb'
 
 import { mongoDbStore, MongoCache } from './node-cache-manager-mongodb'
 
@@ -323,5 +324,17 @@ describe('databaseName', () => {
     expect(baseCache.store.db.databaseName).toEqual('cache')
 
     await baseCache.reset()
+  })
+})
+
+describe('reusing Mongo client', () => {
+  it('should reuse the client', async () => {
+    const mongoClient = new MongoClient('mongodb://localhost:27017')
+    const cache = await caching(mongoDbStore, {
+      client: mongoClient,
+    })
+
+    await cache.set('foo', 'bar')
+    expect(cache.store.client).toEqual(mongoClient)
   })
 })

--- a/packages/node-cache-manager-mongodb/src/lib/node-cache-manager-mongodb.ts
+++ b/packages/node-cache-manager-mongodb/src/lib/node-cache-manager-mongodb.ts
@@ -36,7 +36,9 @@ class MongoDb implements MongoDbStore {
     this.isCacheable = args.isCacheable || ((value: unknown) => value !== undefined && value !== null)
     this.collectionName = args.collectionName || 'cache'
     this.databaseName = args.databaseName || 'cache'
-    if (args.url && args.mongoConfig) {
+    if (args.client) {
+      this.client = args.client
+    } else if (args.url && args.mongoConfig) {
       this.client = new MongoClient(args.url, args.mongoConfig)
     } else if (!args.url && args.mongoConfig) {
       this.client = new MongoClient('mongodb://localhost:27017', args.mongoConfig)

--- a/packages/node-cache-manager-mongodb/src/lib/node-cache-manager-mongodb.ts
+++ b/packages/node-cache-manager-mongodb/src/lib/node-cache-manager-mongodb.ts
@@ -19,6 +19,7 @@ type Args = {
   mongoConfig?: MongoClientOptions
   collectionName?: string
   databaseName?: string
+  client?: MongoClient
 } & Config
 
 


### PR DESCRIPTION
This code currently does not allow you to set the external MongoDb client for re-use. A simple modification to this code would help utilize the external connection pool client